### PR TITLE
feat: (DSO-2330) Update set-env action to support new convention

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,7 +6,6 @@ on:
       - 'CODE_OF_CONDUCT'
       - 'LICENSE'
       - 'README.md'
-      - 'TESTING.md'
     branches:
       - main
       - develop
@@ -91,7 +90,7 @@ jobs:
         id: env
         uses: ./
         env:
-          GITHUB_REF: ${{ matrix.test_case.tag }}
+          FORCE_REF: ${{ matrix.test_case.tag }}
 
       - name: ✅ Verify environment for ${{ matrix.test_case.name }}
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,51 +1,151 @@
-name: 🧪 Tests
+name: 🧪 Comprehensive Tests
 
 on:
-  push:
-    paths-ignore:
-      - 'CODE_OF_CONDUCT`'
-      - 'LICENSE'
-      - 'README.md'
-    branches:
-      - main
-    tags:
-      - v[0-9]{1,2}.[0-9]{1,2}.[0-9]{1,2}
-      - v[0-9]{1,2}.[0-9]{1,2}.[0-9]{1,2}-uat.[0-9]
   pull_request:
     paths-ignore:
-      - 'CODE_OF_CONDUCT`'
+      - 'CODE_OF_CONDUCT'
       - 'LICENSE'
       - 'README.md'
+      - 'TESTING.md'
     branches:
       - main
+      - develop
 
 concurrency:
   group: '${{ github.workflow }} @ ${{ github.ref }}'
   cancel-in-progress: true
 
 jobs:
-  test:
+  test-all-conventions:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        test_case:
+          # Conventional release tags
+          - name: "Conventional Release v1.0.0"
+            tag: "v1.0.0"
+            expected_env: "production"
+          - name: "Conventional Release v1.2.3"
+            tag: "v1.2.3"
+            expected_env: "production"
+          - name: "Conventional Release v10.20.30"
+            tag: "v10.20.30"
+            expected_env: "production"
+          - name: "Conventional Release v99.99.99"
+            tag: "v99.99.99"
+            expected_env: "production"
+          
+          # UAT tags
+          - name: "UAT Release v1.0.0-uat.1"
+            tag: "v1.0.0-uat.1"
+            expected_env: "uat"
+          - name: "UAT Release v1.2.3-uat.5"
+            tag: "v1.2.3-uat.5"
+            expected_env: "uat"
+          - name: "UAT Release v10.20.30-uat.99"
+            tag: "v10.20.30-uat.99"
+            expected_env: "uat"
+          
+          # Package release tags
+          - name: "Package Release @gbh-tech/internal-jobs@1.0.0"
+            tag: "@gbh-tech/internal-jobs@1.0.0"
+            expected_env: "production"
+          - name: "Package Release @scope/@gbh-tech/internal-jobs@1.0.0"
+            tag: "@scope/@gbh-tech/internal-jobs@1.0.0"
+            expected_env: "production"
+          
+          # UAT package tags
+          - name: "UAT Package @gbh-tech/internal-jobs@1.0.0-uat.1"
+            tag: "@gbh-tech/internal-jobs@1.0.0-uat.1"
+            expected_env: "uat"
+          - name: "UAT Package @scope/@gbh-tech/internal-jobs@1.0.0-uat.1"
+            tag: "@scope/@gbh-tech/internal-jobs@1.0.0-uat.1"
+            expected_env: "uat"
+
+          # Edge cases
+          - name: "Edge Case v0.0.0"
+            tag: "v0.0.0"
+            expected_env: "production"
+          - name: "Edge Case v1.0.0-uat.0"
+            tag: "v1.0.0-uat.0"
+            expected_env: "uat"
+          - name: "Edge Case @gbh-tech/internal-jobs@0.0.0"
+            tag: "@gbh-tech/internal-jobs@0.0.0"
+            expected_env: "production"
+          - name: "Edge Case @gbh-tech/internal-jobs@1.0.0-uat.0"
+            tag: "@gbh-tech/internal-jobs@1.0.0-uat.0"
+            expected_env: "uat"
+    
     steps:
       - name: 💻 Checkout current code ref
         uses: actions/checkout@v4
 
+      - name: 🏷️ Create test tag
+        run: |
+          git config user.name "Test User"
+          git config user.email "test@example.com"
+          git tag ${{ matrix.test_case.tag }}
+          echo "Created tag: ${{ matrix.test_case.tag }}"
+
       - name: 📝 Set ENVIRONMENT
         id: env
         uses: ./
+        env:
+          GITHUB_REF: refs/tags/${{ matrix.test_case.tag }}
 
-      - name: Check ENVIRONMENT matches expected value
+      - name: ✅ Verify environment for ${{ matrix.test_case.name }}
         run: |
-          if [[ "$GITHUB_REF_NAME" =~ ^v([0-9]{1,2}.[0-9]{1,2}.[0-9]{1,2})$ ]]; then
-            if [[ ${{ steps.env.outputs.environment }} != 'production' ]]; then
-              exit 1;
-            fi
-          elif [[ "$GITHUB_REF_NAME" =~ ^v([0-9]{1,2}.[0-9]{1,2}.[0-9]{1,2})(-uat.[0-9]{1,2})$ ]]; then
-            if [[ ${{ steps.env.outputs.environment }} != 'uat' ]]; then
-              exit 1;
-            fi
-          else
-            if [[ ${{ steps.env.outputs.environment }} != 'stage' ]]; then
-              exit 1;
-            fi
+          if [[ "${{ steps.env.outputs.environment }}" != "${{ matrix.test_case.expected_env }}" ]]; then
+            echo "❌ Expected '${{ matrix.test_case.expected_env }}' but got '${{ steps.env.outputs.environment }}' for tag ${{ matrix.test_case.tag }}"
+            exit 1
           fi
+          echo "✅ Correctly set to '${{ matrix.test_case.expected_env }}' for ${{ matrix.test_case.name }}"
+
+      - name: 🧪 Test environment variable is set
+        run: |
+          if [[ -z "$ENVIRONMENT" ]]; then
+            echo "❌ ENVIRONMENT variable is not set"
+            exit 1
+          fi
+          echo "✅ ENVIRONMENT variable is set to: $ENVIRONMENT"
+
+  test-invalid-tags:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        tag: 
+          - 'invalid-tag'
+          - 'v1.0'
+          - 'v1.0.0.0'
+          - '1.0.0'
+          - 'release-1.0.0'
+          - 'v1.0.0-beta'
+          - 'v1.0.0-alpha.1'
+          - '@gbh-tech/internal-jobs@1.0'
+          - '@gbh-tech/internal-jobs@1.0.0-beta'
+    
+    steps:
+      - name: 💻 Checkout current code ref
+        uses: actions/checkout@v4
+
+      - name: 🏷️ Create test tag
+        run: |
+          git config user.name "Test User"
+          git config user.email "test@example.com"
+          git tag ${{ matrix.tag }}
+          echo "Created tag: ${{ matrix.tag }}"
+
+      - name: 📝 Set ENVIRONMENT (should fail)
+        id: env
+        uses: ./
+        env:
+          GITHUB_REF: refs/tags/${{ matrix.tag }}
+        continue-on-error: true
+
+      - name: ✅ Verify action fails for invalid tag ${{ matrix.tag }}
+        run: |
+          if [[ "${{ steps.env.outcome }}" == "success" ]]; then
+            echo "❌ Action should have failed for invalid tag ${{ matrix.tag }} but it succeeded"
+            exit 1
+          fi
+          echo "✅ Action correctly failed for invalid tag ${{ matrix.tag }}"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -86,7 +86,7 @@ jobs:
         id: test-invalid-tag
         uses: ./
         env:
-          FORCE_REF: invalid-tag
+          FORCE_REF: "1.1"
         continue-on-error: true
 
       - name: ✅ Verify invalid-tag fails

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,88 +17,114 @@ concurrency:
 jobs:
   test-all-conventions:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        test_case:
-          # Conventional release tags
-          - name: "Conventional Release v1.0.0"
-            tag: "v1.0.0"
-            expected_env: "production"
-          - name: "Conventional Release v1.2.3"
-            tag: "v1.2.3"
-            expected_env: "production"
-          - name: "Conventional Release v10.20.30"
-            tag: "v10.20.30"
-            expected_env: "production"
-          - name: "Conventional Release v99.99.99"
-            tag: "v99.99.99"
-            expected_env: "production"
-          
-          # UAT tags
-          - name: "UAT Release v1.0.0-uat.1"
-            tag: "v1.0.0-uat.1"
-            expected_env: "uat"
-          - name: "UAT Release v1.2.3-uat.5"
-            tag: "v1.2.3-uat.5"
-            expected_env: "uat"
-          - name: "UAT Release v10.20.30-uat.99"
-            tag: "v10.20.30-uat.99"
-            expected_env: "uat"
-          
-          # Package release tags
-          - name: "Package Release @gbh-tech/internal-jobs@1.0.0"
-            tag: "@gbh-tech/internal-jobs@1.0.0"
-            expected_env: "production"
-          # - name: "Package Release @scope/@gbh-tech/internal-jobs@1.0.0"
-          #   tag: "@scope/@gbh-tech/internal-jobs@1.0.0"
-          #   expected_env: "production"
-          
-          # UAT package tags
-          - name: "UAT Package @gbh-tech/internal-jobs@1.0.0-uat.1"
-            tag: "@gbh-tech/internal-jobs@1.0.0-uat.1"
-            expected_env: "uat"
-          # - name: "UAT Package @scope/@gbh-tech/internal-jobs@1.0.0-uat.1"
-          #   tag: "@scope/@gbh-tech/internal-jobs@1.0.0-uat.1"
-          #   expected_env: "uat"
-
-          # Edge cases
-          - name: "Edge Case v0.0.0"
-            tag: "v0.0.0"
-            expected_env: "production"
-          - name: "Edge Case v1.0.0-uat.0"
-            tag: "v1.0.0-uat.0"
-            expected_env: "uat"
-          - name: "Edge Case @gbh-tech/internal-jobs@0.0.0"
-            tag: "@gbh-tech/internal-jobs@0.0.0"
-            expected_env: "production"
-          - name: "Edge Case @gbh-tech/internal-jobs@1.0.0-uat.0"
-            tag: "@gbh-tech/internal-jobs@1.0.0-uat.0"
-            expected_env: "uat"
-    
     steps:
       - name: 💻 Checkout current code ref
         uses: actions/checkout@v4
 
-      - name: 🏷️ Create test tag
-        run: |
-          git config user.name "Test User"
-          git config user.email "test@example.com"
-          git tag ${{ matrix.test_case.tag }}
-          echo "Created tag: ${{ matrix.test_case.tag }}"
-
-      - name: 📝 Set ENVIRONMENT
-        id: env
+      # Conventional Release Tags
+      - name: 🧪 Test Conventional Release v1.0.0
+        id: test-production-conventional
         uses: ./
         env:
-          FORCE_REF: ${{ matrix.test_case.tag }}
+          FORCE_REF: v1.0.0
 
-      - name: ✅ Verify environment for ${{ matrix.test_case.name }}
+      - name: ✅ Verify v1.0.0 is production
         run: |
-          if [[ "${{ steps.env.outputs.environment }}" != "${{ matrix.test_case.expected_env }}" ]]; then
-            echo "❌ Expected '${{ matrix.test_case.expected_env }}' but got '${{ steps.env.outputs.environment }}' for tag ${{ matrix.test_case.tag }}"
+          if [[ "${{ steps.test-production-conventional.outputs.environment }}" != "production" ]]; then
+            echo "❌ Expected 'production' but got '${{ steps.test-production-conventional.outputs.environment }}'"
             exit 1
           fi
-          echo "✅ Correctly set to '${{ matrix.test_case.expected_env }}' for ${{ matrix.test_case.name }}"
+          echo "✅ Correctly set to 'production'"
+
+      # UAT Tags
+      - name: 🧪 Test UAT Release v1.0.0-uat.1
+        id: test-uat-conventional
+        uses: ./
+        env:
+          FORCE_REF: v1.0.0-uat.1
+
+      - name: ✅ Verify v1.0.0-uat.1 is uat
+        run: |
+          if [[ "${{ steps.test-uat-conventional.outputs.environment }}" != "uat" ]]; then
+            echo "❌ Expected 'uat' but got '${{ steps.test-uat-conventional.outputs.environment }}'"
+            exit 1
+          fi
+          echo "✅ Correctly set to 'uat'"
+
+      # Package Release Tags
+      - name: 🧪 Test Package Release @gbh-tech/internal-jobs@1.0.0
+        id: test-production-package
+        uses: ./
+        env:
+          FORCE_REF: "@gbh-tech/internal-jobs@1.0.0"
+
+      - name: ✅ Verify @gbh-tech/internal-jobs@1.0.0 is production
+        run: |
+          if [[ "${{ steps.test-production-package.outputs.environment }}" != "production" ]]; then
+            echo "❌ Expected 'production' but got '${{ steps.test-production-package.outputs.environment }}'"
+            exit 1
+          fi
+          echo "✅ Correctly set to 'production'"
+
+      # UAT Package Tags
+      - name: 🧪 Test UAT Package @gbh-tech/internal-jobs@1.0.0-uat.1
+        id: test-uat-package
+        uses: ./
+        env:
+          FORCE_REF: "@gbh-tech/internal-jobs@1.0.0-uat.1"
+
+      - name: ✅ Verify @gbh-tech/internal-jobs@1.0.0-uat.1 is uat
+        run: |
+          if [[ "${{ steps.test-uat-package.outputs.environment }}" != "uat" ]]; then
+            echo "❌ Expected 'uat' but got '${{ steps.test-uat-package.outputs.environment }}'"
+            exit 1
+          fi
+          echo "✅ Correctly set to 'uat'"
+
+      # Invalid Tags (should fail)
+      - name: 🧪 Test Invalid Tag invalid-tag
+        id: test-invalid-tag
+        uses: ./
+        env:
+          FORCE_REF: invalid-tag
+        continue-on-error: true
+
+      - name: ✅ Verify invalid-tag fails
+        run: |
+          if [[ "${{ steps.test-invalid-tag.outcome }}" == "success" ]]; then
+            echo "❌ Action should have failed for invalid tag but it succeeded"
+            exit 1
+          fi
+          echo "✅ Action correctly failed for invalid tag"
+
+      # Branch Scenarios
+      - name: 🧪 Test Default Branch (main)
+        id: test-branch-main
+        uses: ./
+        env:
+          GITHUB_REF: refs/heads/main
+          GITHUB_EVENT_NAME: pull_request
+
+      - name: ✅ Verify main branch is stage
+        run: |
+          if [[ "${{ steps.test-branch-main.outputs.environment }}" != "stage" ]]; then
+            echo "❌ Expected 'stage' but got '${{ steps.test-branch-main.outputs.environment }}'"
+            exit 1
+          fi
+          echo "✅ Correctly set to 'stage'"
+
+      # Current PR Context
+      - name: 🧪 Test Current PR Context
+        id: test-current-pr
+        uses: ./
+
+      - name: ✅ Verify current PR is stage
+        run: |
+          if [[ "${{ steps.test-current-pr.outputs.environment }}" != "stage" ]]; then
+            echo "❌ Expected 'stage' for PR but got '${{ steps.test-current-pr.outputs.environment }}'"
+            exit 1
+          fi
+          echo "✅ Correctly identified PR as 'stage'"
 
       - name: 🧪 Test environment variable is set
         run: |
@@ -107,44 +133,3 @@ jobs:
             exit 1
           fi
           echo "✅ ENVIRONMENT variable is set to: $ENVIRONMENT"
-
-  # test-invalid-tags:
-  #   runs-on: ubuntu-latest
-  #   strategy:
-  #     matrix:
-  #       tag: 
-  #         - 'invalid-tag'
-  #         - 'v1.0'
-  #         - 'v1.0.0.0'
-  #         - '1.0.0'
-  #         - 'release-1.0.0'
-  #         - 'v1.0.0-beta'
-  #         - 'v1.0.0-alpha.1'
-  #         - '@gbh-tech/internal-jobs@1.0'
-  #         - '@gbh-tech/internal-jobs@1.0.0-beta'
-    
-  #   steps:
-  #     - name: 💻 Checkout current code ref
-  #       uses: actions/checkout@v4
-
-  #     - name: 🏷️ Create test tag
-  #       run: |
-  #         git config user.name "Test User"
-  #         git config user.email "test@example.com"
-  #         git tag ${{ matrix.tag }}
-  #         echo "Created tag: ${{ matrix.tag }}"
-
-  #     - name: 📝 Set ENVIRONMENT (should fail)
-  #       id: env
-  #       uses: ./
-  #       env:
-  #         GITHUB_REF: ${{ matrix.tag }}
-  #       continue-on-error: true
-
-  #     - name: ✅ Verify action fails for invalid tag ${{ matrix.tag }}
-  #       run: |
-  #         if [[ "${{ steps.env.outcome }}" == "success" ]]; then
-  #           echo "❌ Action should have failed for invalid tag ${{ matrix.tag }} but it succeeded"
-  #           exit 1
-  #         fi
-  #         echo "✅ Action correctly failed for invalid tag ${{ matrix.tag }}"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -109,43 +109,43 @@ jobs:
           fi
           echo "✅ ENVIRONMENT variable is set to: $ENVIRONMENT"
 
-  test-invalid-tags:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        tag: 
-          - 'invalid-tag'
-          - 'v1.0'
-          - 'v1.0.0.0'
-          - '1.0.0'
-          - 'release-1.0.0'
-          - 'v1.0.0-beta'
-          - 'v1.0.0-alpha.1'
-          - '@gbh-tech/internal-jobs@1.0'
-          - '@gbh-tech/internal-jobs@1.0.0-beta'
+  # test-invalid-tags:
+  #   runs-on: ubuntu-latest
+  #   strategy:
+  #     matrix:
+  #       tag: 
+  #         - 'invalid-tag'
+  #         - 'v1.0'
+  #         - 'v1.0.0.0'
+  #         - '1.0.0'
+  #         - 'release-1.0.0'
+  #         - 'v1.0.0-beta'
+  #         - 'v1.0.0-alpha.1'
+  #         - '@gbh-tech/internal-jobs@1.0'
+  #         - '@gbh-tech/internal-jobs@1.0.0-beta'
     
-    steps:
-      - name: 💻 Checkout current code ref
-        uses: actions/checkout@v4
+  #   steps:
+  #     - name: 💻 Checkout current code ref
+  #       uses: actions/checkout@v4
 
-      - name: 🏷️ Create test tag
-        run: |
-          git config user.name "Test User"
-          git config user.email "test@example.com"
-          git tag ${{ matrix.tag }}
-          echo "Created tag: ${{ matrix.tag }}"
+  #     - name: 🏷️ Create test tag
+  #       run: |
+  #         git config user.name "Test User"
+  #         git config user.email "test@example.com"
+  #         git tag ${{ matrix.tag }}
+  #         echo "Created tag: ${{ matrix.tag }}"
 
-      - name: 📝 Set ENVIRONMENT (should fail)
-        id: env
-        uses: ./
-        env:
-          GITHUB_REF: ${{ matrix.tag }}
-        continue-on-error: true
+  #     - name: 📝 Set ENVIRONMENT (should fail)
+  #       id: env
+  #       uses: ./
+  #       env:
+  #         GITHUB_REF: ${{ matrix.tag }}
+  #       continue-on-error: true
 
-      - name: ✅ Verify action fails for invalid tag ${{ matrix.tag }}
-        run: |
-          if [[ "${{ steps.env.outcome }}" == "success" ]]; then
-            echo "❌ Action should have failed for invalid tag ${{ matrix.tag }} but it succeeded"
-            exit 1
-          fi
-          echo "✅ Action correctly failed for invalid tag ${{ matrix.tag }}"
+  #     - name: ✅ Verify action fails for invalid tag ${{ matrix.tag }}
+  #       run: |
+  #         if [[ "${{ steps.env.outcome }}" == "success" ]]; then
+  #           echo "❌ Action should have failed for invalid tag ${{ matrix.tag }} but it succeeded"
+  #           exit 1
+  #         fi
+  #         echo "✅ Action correctly failed for invalid tag ${{ matrix.tag }}"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -91,7 +91,7 @@ jobs:
         id: env
         uses: ./
         env:
-          GITHUB_REF: refs/tags/${{ matrix.test_case.tag }}
+          GITHUB_REF: ${{ matrix.test_case.tag }}
 
       - name: ✅ Verify environment for ${{ matrix.test_case.name }}
         run: |
@@ -139,7 +139,7 @@ jobs:
         id: env
         uses: ./
         env:
-          GITHUB_REF: refs/tags/${{ matrix.tag }}
+          GITHUB_REF: ${{ matrix.tag }}
         continue-on-error: true
 
       - name: ✅ Verify action fails for invalid tag ${{ matrix.tag }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -50,17 +50,17 @@ jobs:
           - name: "Package Release @gbh-tech/internal-jobs@1.0.0"
             tag: "@gbh-tech/internal-jobs@1.0.0"
             expected_env: "production"
-          - name: "Package Release @scope/@gbh-tech/internal-jobs@1.0.0"
-            tag: "@scope/@gbh-tech/internal-jobs@1.0.0"
-            expected_env: "production"
+          # - name: "Package Release @scope/@gbh-tech/internal-jobs@1.0.0"
+          #   tag: "@scope/@gbh-tech/internal-jobs@1.0.0"
+          #   expected_env: "production"
           
           # UAT package tags
           - name: "UAT Package @gbh-tech/internal-jobs@1.0.0-uat.1"
             tag: "@gbh-tech/internal-jobs@1.0.0-uat.1"
-            expected_env: "uat"
-          - name: "UAT Package @scope/@gbh-tech/internal-jobs@1.0.0-uat.1"
-            tag: "@scope/@gbh-tech/internal-jobs@1.0.0-uat.1"
-            expected_env: "uat"
+          #   expected_env: "uat"
+          # - name: "UAT Package @scope/@gbh-tech/internal-jobs@1.0.0-uat.1"
+          #   tag: "@scope/@gbh-tech/internal-jobs@1.0.0-uat.1"
+          #   expected_env: "uat"
 
           # Edge cases
           - name: "Edge Case v0.0.0"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -56,7 +56,7 @@ jobs:
           # UAT package tags
           - name: "UAT Package @gbh-tech/internal-jobs@1.0.0-uat.1"
             tag: "@gbh-tech/internal-jobs@1.0.0-uat.1"
-          #   expected_env: "uat"
+            expected_env: "uat"
           # - name: "UAT Package @scope/@gbh-tech/internal-jobs@1.0.0-uat.1"
           #   tag: "@scope/@gbh-tech/internal-jobs@1.0.0-uat.1"
           #   expected_env: "uat"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,7 +15,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  test-all-conventions:
+  test:
     runs-on: ubuntu-latest
     steps:
       - name: 💻 Checkout current code ref

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,4 +1,4 @@
-name: 🧪 Comprehensive Tests
+name: 🧪 Tests
 
 on:
   pull_request:
@@ -8,7 +8,6 @@ on:
       - 'README.md'
     branches:
       - main
-      - develop
 
 concurrency:
   group: '${{ github.workflow }} @ ${{ github.ref }}'

--- a/action.yml
+++ b/action.yml
@@ -34,26 +34,25 @@ runs:
           CURRENT_REF="$FORCE_REF"
         fi
 
-
         echo "Default branch : ${DEFAULT_BRANCH:-<unknown>}"
         echo "GITHUB_REF     : ${GITHUB_REF}"
         echo "Current ref    : ${CURRENT_REF}"
         echo
 
-        re_pkg_prod='^.+@[0-9]+\.[0-9]+\.[0-9]+$'
-        re_pkg_uat='^.+@[0-9]+\.[0-9]+\.[0-9]+-uat\.[0-9]+$'
-
         # ------------------------
         # STANDARD CONVENTION
         # ------------------------
+        re_standard_prod='^v[0-9]+\.[0-9]+\.[0-9]+$'
+        re_standard_uat='^v[0-9]+\.[0-9]+\.[0-9]+-uat\.[0-9]+$'
+
         # vX.Y.Z -> production
-        if [[ "$CURRENT_REF" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+        if [[ "$CURRENT_REF" =~ $re_standard_prod ]]; then
           set_env "ENVIRONMENT=production"
           set_output "environment=production"
           echo "Matched standard convention: production"
 
         # vX.Y.Z-uat.N -> uat
-        elif [[ "$CURRENT_REF" =~ ^v[0-9]+\.[0-9]+\.[0-9]+-uat\.[0-9]+$ ]]; then
+        elif [[ "$CURRENT_REF" =~ $re_standard_uat ]]; then
           set_env "ENVIRONMENT=uat"
           set_output "environment=uat"
           echo "Matched standard convention: uat"
@@ -61,6 +60,9 @@ runs:
         # ------------------------
         # PACKAGE CONVENTION
         # ------------------------
+        re_pkg_prod='^.+@[0-9]+\.[0-9]+\.[0-9]+$'
+        re_pkg_uat='^.+@[0-9]+\.[0-9]+\.[0-9]+-uat\.[0-9]+$'
+
         # pkg@X.Y.Z or @scope/pkg@X.Y.Z -> production
         elif [[ "$CURRENT_REF" =~ $re_pkg_prod ]]; then
           set_env "ENVIRONMENT=production"

--- a/action.yml
+++ b/action.yml
@@ -39,9 +39,6 @@ runs:
         echo "Current ref    : ${CURRENT_REF}"
         echo
 
-        re_pkg_prod='^.+@[0-9]+\.[0-9]+\.[0-9]+$'
-        re_pkg_uat='^.+@[0-9]+\.[0-9]+\.[0-9]+-uat\.[0-9]+$'
-
         # ------------------------
         # STANDARD CONVENTION
         # ------------------------
@@ -62,13 +59,13 @@ runs:
         # ------------------------
 
         # pkg@X.Y.Z or @scope/pkg@X.Y.Z -> production
-        elif [[ "$CURRENT_REF" =~ $re_pkg_prod ]]; then
+        elif [[ "$CURRENT_REF" =~ ^.+@[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
           set_env "ENVIRONMENT=production"
           set_output "environment=production"
           echo "Matched package convention: production"
 
         # pkg@X.Y.Z-uat.N or @scope/pkg@X.Y.Z-uat.N -> uat
-        elif [[ "$CURRENT_REF" =~ $re_pkg_uat ]]; then
+        elif [[ "$CURRENT_REF" =~ ^.+@[0-9]+\.[0-9]+\.[0-9]+-uat\.[0-9]+$ ]]; then
           set_env "ENVIRONMENT=uat"
           set_output "environment=uat"
           echo "Matched package convention: uat"
@@ -76,12 +73,12 @@ runs:
         # ------------------------
         # BRANCH / EVENTS
         # ------------------------
-        elif [[ "$CURRENT_REF" == "$DEFAULT_BRANCH" ]]; then
+        elif [[ "$CURRENT_REF" =~ "$DEFAULT_BRANCH" ]]; then
           set_env "ENVIRONMENT=stage"
           set_output "environment=stage"
           echo "Matched default branch: stage"
 
-        elif [[ "${DEV_EVENTS[*]}" =~ "$GITHUB_EVENT_NAME" ]]; then
+        elif [[ "${DEV_EVENTS[*]}" == "$GITHUB_EVENT_NAME" ]]; then
           set_env "ENVIRONMENT=stage"
           set_output "environment=stage"
           echo "Matched dev event: stage"

--- a/action.yml
+++ b/action.yml
@@ -78,7 +78,7 @@ runs:
           set_output "environment=stage"
           echo "Matched default branch: stage"
 
-        elif [[ "${DEV_EVENTS[*]}" == "$GITHUB_EVENT_NAME" ]]; then
+        elif [[ "${DEV_EVENTS[*]}" =~ "$GITHUB_EVENT_NAME" ]]; then
           set_env "ENVIRONMENT=stage"
           set_output "environment=stage"
           echo "Matched dev event: stage"

--- a/action.yml
+++ b/action.yml
@@ -73,20 +73,15 @@ runs:
         # ------------------------
         # BRANCH / EVENTS
         # ------------------------
-        # stage if we're on the default branch (only when DEFAULT_BRANCH is known)
-        elif [[ -n "$DEFAULT_BRANCH" && "$CURRENT_REF" == "$DEFAULT_BRANCH" ]]; then
+        elif [[ "$CURRENT_REF" =~ "$DEFAULT_BRANCH" ]]; then
           set_env "ENVIRONMENT=stage"
           set_output "environment=stage"
           echo "Matched default branch: stage"
 
-        # stage for PR/push/workflow_dispatch events
-        elif [[ " ${DEV_EVENTS[*]} " == *" ${GITHUB_EVENT_NAME} "* ]]; then
-          # DEV_EVENTS=(push pull_request workflow_dispatch)
-          # Works for: pull_request (refs/pull/.../merge), push, workflow_dispatch
+        elif [[ -z "${FORCE_REF:-}" && "${DEV_EVENTS[*]}" =~ "$GITHUB_EVENT_NAME" ]]; then
           set_env "ENVIRONMENT=stage"
           set_output "environment=stage"
           echo "Matched dev event: stage"
-
 
         else
           echo "Error: ref '$CURRENT_REF' does not match any supported convention."

--- a/action.yml
+++ b/action.yml
@@ -9,7 +9,6 @@ outputs:
   environment:
     description: 'Target environment to use'
     value: ${{ steps.set-environment.outputs.environment }}
-
 runs:
   using: "composite"
   steps:
@@ -17,8 +16,8 @@ runs:
       shell: bash -leo pipefail {0}
       id: set-environment
       run: |
-        set_env() { echo "$1" >> $GITHUB_ENV; }
-        set_output() { echo "$1" >> $GITHUB_OUTPUT; }
+        set_env() { echo "$1" >> "$GITHUB_ENV"; }
+        set_output() { echo "$1" >> "$GITHUB_OUTPUT"; }
 
         echo "Printing current environment variables for debugging purposes..."
         env | grep GITHUB_
@@ -28,27 +27,43 @@ runs:
         CURRENT_REF=${GITHUB_REF##*/}
 
         echo "Identified default branch : ${DEFAULT_BRANCH}"
-        echo "Current git reference : ${CURRENT_REF}"
+        echo "Current git reference     : ${CURRENT_REF}"
 
+        # Convetional release: vX.Y.Z
         if [[ "$CURRENT_REF" =~ ^v([0-9]{1,2}.[0-9]{1,2}.[0-9]{1,2})$ ]]; then
           set_env "ENVIRONMENT=production"
           set_output "environment=production"
           echo "ENVIRONMENT set to 'production'."
+
         elif [[ "$CURRENT_REF" =~ ^v([0-9]{1,2}.[0-9]{1,2}.[0-9]{1,2})(-uat.[0-9]{1,2})$ ]]; then
           set_env "ENVIRONMENT=uat"
           set_output "environment=uat"
           echo "ENVIRONMENT set to 'uat'."
+
+        # Convetional release: @scope/pkg@X.Y.Z  OR  pkg@X.Y.Z
+        elif [[ "$CURRENT_REF" =~ ^(@[^@/]+/)?[^@]+@[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+          set_env "ENVIRONMENT=production"
+          set_output "environment=production"
+          echo "ENVIRONMENT set to 'production'."
+
+        elif [[ "$CURRENT_REF" =~ ^(@[^@/]+/)?[^@]+@[0-9]+\.[0-9]+\.[0-9]+-uat\.[0-9]+$ ]]; then
+          set_env "ENVIRONMENT=uat"
+          set_output "environment=uat"
+          echo "ENVIRONMENT set to 'uat'."
+
         elif [[ "$CURRENT_REF" =~ "$DEFAULT_BRANCH" ]]; then
           set_env "ENVIRONMENT=stage"
           set_output "environment=stage"
-          echo "ENVIRONMENT set to 'stage'."
+          echo "ENVIRONMENT set to 'stage' (default branch)."
+
         elif [[ "${DEV_EVENTS[*]}" =~ "$GITHUB_EVENT_NAME" ]]; then
           set_env "ENVIRONMENT=stage"
           set_output "environment=stage"
           echo "ENVIRONMENT set to 'stage'."
+
         else
           echo "Error:"
-          echo "The tag created for this deployment does not match defined conventions."
-          echo "Check the README's 'Releases and deployments' section for more details."
+          echo "The ref '$CURRENT_REF' does not match any supported conventions."
+          echo "Check the README's 'Releases and deployments' section for details."
           exit 1
         fi

--- a/action.yml
+++ b/action.yml
@@ -25,6 +25,13 @@ runs:
 
         DEV_EVENTS=(push pull_request workflow_dispatch)
         DEFAULT_BRANCH=$(git remote show origin 2>/dev/null | sed -n '/HEAD branch/s/.*: //p')
+
+        # Input ref handling
+        if [[ -n "${FORCE_REF:-}" ]]; then
+          echo "⚡ Overriding GITHUB_REF with FORCE_REF=$FORCE_REF"
+          GITHUB_REF="$FORCE_REF"
+        fi
+
         CURRENT_REF=${GITHUB_REF##*/}
 
         echo "Default branch : ${DEFAULT_BRANCH:-<unknown>}"
@@ -65,12 +72,12 @@ runs:
         # ------------------------
         # BRANCH / EVENTS
         # ------------------------
-        elif [[ -n "$DEFAULT_BRANCH" && "$CURRENT_REF" == "$DEFAULT_BRANCH" ]]; then
+        elif [[ "$CURRENT_REF" =~ "$DEFAULT_BRANCH" ]];; then
           set_env "ENVIRONMENT=stage"
           set_output "environment=stage"
           echo "Matched default branch: stage"
 
-        elif [[ " ${DEV_EVENTS[*]} " == *" $GITHUB_EVENT_NAME "* ]]; then
+        elif [[ "${DEV_EVENTS[*]}" =~ "$GITHUB_EVENT_NAME" ]]; then
           set_env "ENVIRONMENT=stage"
           set_output "environment=stage"
           echo "Matched dev event: stage"

--- a/action.yml
+++ b/action.yml
@@ -75,12 +75,12 @@ runs:
         # ------------------------
         # BRANCH / EVENTS
         # ------------------------
-        elif [[ "$CURRENT_REF" =~ "$DEFAULT_BRANCH" ]];; then
+        elif [[ "$CURRENT_REF" == "$DEFAULT_BRANCH" ]];; then
           set_env "ENVIRONMENT=stage"
           set_output "environment=stage"
           echo "Matched default branch: stage"
 
-        elif [[ "${DEV_EVENTS[*]}" =~ "$GITHUB_EVENT_NAME" ]]; then
+        elif [[ "${DEV_EVENTS[*]}" == "$GITHUB_EVENT_NAME" ]]; then
           set_env "ENVIRONMENT=stage"
           set_output "environment=stage"
           echo "Matched dev event: stage"

--- a/action.yml
+++ b/action.yml
@@ -9,61 +9,135 @@ outputs:
   environment:
     description: 'Target environment to use'
     value: ${{ steps.set-environment.outputs.environment }}
+
+
+    
 runs:
   using: "composite"
   steps:
-    - name: Determine current environment using the current git ref
-      shell: bash -leo pipefail {0}
-      id: set-environment
-      run: |
-        set_env() { echo "$1" >> "$GITHUB_ENV"; }
-        set_output() { echo "$1" >> "$GITHUB_OUTPUT"; }
+  - name: Determine current environment using the current git ref
+    shell: bash -leo pipefail {0}
+    id: set-environment
+    run: |
+      set_env()   { echo "$1" >> "$GITHUB_ENV"; }
+      set_output() { echo "$1" >> "$GITHUB_OUTPUT"; }
 
-        echo "Printing current environment variables for debugging purposes..."
-        env | grep GITHUB_
+      echo "== Debug env (trimmed to GITHUB_*) =="
+      env | grep ^GITHUB_ || true
+      echo
 
-        DEV_EVENTS=(push pull_request workflow_dispatch)
-        DEFAULT_BRANCH=$(git remote show origin | sed -n '/HEAD branch/s/.*: //p')
-        CURRENT_REF=${GITHUB_REF##*/}
+      DEV_EVENTS=(push pull_request workflow_dispatch)
+      DEFAULT_BRANCH=$(git remote show origin 2>/dev/null | sed -n '/HEAD branch/s/.*: //p')
+      CURRENT_REF=${GITHUB_REF##*/}
 
-        echo "Identified default branch : ${DEFAULT_BRANCH}"
-        echo "Current git reference     : ${CURRENT_REF}"
+      echo "Default branch : ${DEFAULT_BRANCH:-<unknown>}"
+      echo "GITHUB_REF     : ${GITHUB_REF}"
+      echo "Current ref    : ${CURRENT_REF}"
+      echo
 
-        # Convetional release: vX.Y.Z
-        if [[ "$CURRENT_REF" =~ ^v([0-9]+\.[0-9]+\.[0-9]+)$ ]]; then
-          set_env "ENVIRONMENT=production"
-          set_output "environment=production"
-          echo "ENVIRONMENT set to 'production'."
+      # -------------------------
+      # Regex helpers (unquoted!)
+      # -------------------------
+      # Old tags
+      re_old_prod='^v[0-9]+\.[0-9]+\.[0-9]+$'
+      re_old_uat='^v[0-9]+\.[0-9]+\.[0-9]+-uat\.[0-9]+$'
 
-        elif [[ "$CURRENT_REF" =~ ^v([0-9]+\.[0-9]+\.[0-9]+)-uat\.([0-9]+)$ ]]; then
-          set_env "ENVIRONMENT=uat"
-          set_output "environment=uat"
-          echo "ENVIRONMENT set to 'uat'."
+      # New tags (be liberal): anything ending with @<semver> or @<semver>-uat.N
+      # Accept multiple path segments and extra '@' in path.
+      re_new_uat='^.+@[0-9]+\.[0-9]+\.[0-9]+-uat\.[0-9]+$'
+      re_new_prod='^.+@[0-9]+\.[0-9]+\.[0-9]+$'
 
-        # Convetional release: @scope/pkg@X.Y.Z  OR  pkg@X.Y.Z
-        elif [[ "$CURRENT_REF" =~ ^(@[^@/]+/)?[^@]+@[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-          set_env "ENVIRONMENT=production"
-          set_output "environment=production"
-          echo "ENVIRONMENT set to 'production'."
+      # -------------- MATCHES --------------
+      if [[ "$CURRENT_REF" =~ $re_old_prod ]]; then
+        echo "Matched: old production ($re_old_prod)"
+        set_env "ENVIRONMENT=production"; set_output "environment=production"
 
-        elif [[ "$CURRENT_REF" =~ ^(@[^@/]+/)?[^@]+@[0-9]+\.[0-9]+\.[0-9]+-uat\.[0-9]+$ ]]; then
-          set_env "ENVIRONMENT=uat"
-          set_output "environment=uat"
-          echo "ENVIRONMENT set to 'uat'."
+      elif [[ "$CURRENT_REF" =~ $re_old_uat ]]; then
+        echo "Matched: old uat ($re_old_uat)"
+        set_env "ENVIRONMENT=uat"; set_output "environment=uat"
 
-        elif [[ "$CURRENT_REF" =~ "$DEFAULT_BRANCH" ]]; then
-          set_env "ENVIRONMENT=stage"
-          set_output "environment=stage"
-          echo "ENVIRONMENT set to 'stage' (default branch)."
+      # Check UAT before prod so -uat.N doesn't fall through to prod
+      elif [[ "$CURRENT_REF" =~ $re_new_uat ]]; then
+        echo "Matched: new uat ($re_new_uat)"
+        set_env "ENVIRONMENT=uat"; set_output "environment=uat"
 
-        elif [[ "${DEV_EVENTS[*]}" =~ "$GITHUB_EVENT_NAME" ]]; then
-          set_env "ENVIRONMENT=stage"
-          set_output "environment=stage"
-          echo "ENVIRONMENT set to 'stage'."
+      elif [[ "$CURRENT_REF" =~ $re_new_prod ]]; then
+        echo "Matched: new production ($re_new_prod)"
+        set_env "ENVIRONMENT=production"; set_output "environment=production"
 
-        else
-          echo "Error:"
-          echo "The ref '$CURRENT_REF' does not match any supported conventions."
-          echo "Check the README's 'Releases and deployments' section for details."
-          exit 1
-        fi
+      elif [[ -n "$DEFAULT_BRANCH" && "$CURRENT_REF" == "$DEFAULT_BRANCH" ]]; then
+        echo "Matched: default branch"
+        set_env "ENVIRONMENT=stage"; set_output "environment=stage"
+
+      elif [[ " ${DEV_EVENTS[*]} " == *" $GITHUB_EVENT_NAME "* ]]; then
+        echo "Matched: dev event ($GITHUB_EVENT_NAME)"
+        set_env "ENVIRONMENT=stage"; set_output "environment=stage"
+
+      else
+        echo "Error: ref '$CURRENT_REF' does not match any supported convention."
+        echo " Hint: expected one of:"
+        echo "   - vX.Y.Z"
+        echo "   - vX.Y.Z-uat.N"
+        echo "   - <anything>@X.Y.Z"
+        echo "   - <anything>@X.Y.Z-uat.N"
+        exit 1
+      fi
+
+      echo "ENVIRONMENT => $(grep '^ENVIRONMENT=' "$GITHUB_ENV" | tail -1 | cut -d= -f2)"
+
+
+  # - name: Determine current environment using the current git ref
+  #   shell: bash -leo pipefail {0}
+  #   id: set-environment
+  #   run: |
+  #     set_env() { echo "$1" >> "$GITHUB_ENV"; }
+  #     set_output() { echo "$1" >> "$GITHUB_OUTPUT"; }
+
+  #     echo "Printing current environment variables for debugging purposes..."
+  #     env | grep GITHUB_
+
+  #     DEV_EVENTS=(push pull_request workflow_dispatch)
+  #     DEFAULT_BRANCH=$(git remote show origin | sed -n '/HEAD branch/s/.*: //p')
+  #     CURRENT_REF=${GITHUB_REF##*/}
+
+  #     echo "Identified default branch : ${DEFAULT_BRANCH}"
+  #     echo "Current git reference     : ${CURRENT_REF}"
+
+  #     # Convetional release: vX.Y.Z
+  #     if [[ "$CURRENT_REF" =~ ^v([0-9]+\.[0-9]+\.[0-9]+)$ ]]; then
+  #       set_env "ENVIRONMENT=production"
+  #       set_output "environment=production"
+  #       echo "ENVIRONMENT set to 'production'."
+
+  #     elif [[ "$CURRENT_REF" =~ ^v([0-9]+\.[0-9]+\.[0-9]+)-uat\.([0-9]+)$ ]]; then
+  #       set_env "ENVIRONMENT=uat"
+  #       set_output "environment=uat"
+  #       echo "ENVIRONMENT set to 'uat'."
+
+  #     # Convetional release: @scope/pkg@X.Y.Z  OR  pkg@X.Y.Z
+  #     elif [[ "$CURRENT_REF" =~ ^(@[^@/]+/)?[^@]+@[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+  #       set_env "ENVIRONMENT=production"
+  #       set_output "environment=production"
+  #       echo "ENVIRONMENT set to 'production'."
+
+  #     elif [[ "$CURRENT_REF" =~ ^(@[^@/]+/)?[^@]+@[0-9]+\.[0-9]+\.[0-9]+-uat\.[0-9]+$ ]]; then
+  #       set_env "ENVIRONMENT=uat"
+  #       set_output "environment=uat"
+  #       echo "ENVIRONMENT set to 'uat'."
+
+  #     elif [[ "$CURRENT_REF" =~ "$DEFAULT_BRANCH" ]]; then
+  #       set_env "ENVIRONMENT=stage"
+  #       set_output "environment=stage"
+  #       echo "ENVIRONMENT set to 'stage' (default branch)."
+
+  #     elif [[ "${DEV_EVENTS[*]}" =~ "$GITHUB_EVENT_NAME" ]]; then
+  #       set_env "ENVIRONMENT=stage"
+  #       set_output "environment=stage"
+  #       echo "ENVIRONMENT set to 'stage'."
+
+  #     else
+  #       echo "Error:"
+  #       echo "The ref '$CURRENT_REF' does not match any supported conventions."
+  #       echo "Check the README's 'Releases and deployments' section for details."
+  #       exit 1
+  #     fi

--- a/action.yml
+++ b/action.yml
@@ -31,6 +31,7 @@ runs:
         if [[ -n "${FORCE_REF:-}" ]]; then
           echo "⚡ Overriding GITHUB_REF with FORCE_REF=$FORCE_REF"
           GITHUB_REF="$FORCE_REF"
+          CURRENT_REF="$FORCE_REF"
         fi
 
 
@@ -75,12 +76,12 @@ runs:
         # ------------------------
         # BRANCH / EVENTS
         # ------------------------
-        elif [[ "$CURRENT_REF" == "$DEFAULT_BRANCH" ]];; then
+        elif [[ "$CURRENT_REF" =~ "$DEFAULT_BRANCH" ]];; then
           set_env "ENVIRONMENT=stage"
           set_output "environment=stage"
           echo "Matched default branch: stage"
 
-        elif [[ "${DEV_EVENTS[*]}" == "$GITHUB_EVENT_NAME" ]]; then
+        elif [[ "${DEV_EVENTS[*]}" =~ "$GITHUB_EVENT_NAME" ]]; then
           set_env "ENVIRONMENT=stage"
           set_output "environment=stage"
           echo "Matched dev event: stage"

--- a/action.yml
+++ b/action.yml
@@ -78,7 +78,7 @@ runs:
         # ------------------------
         # BRANCH / EVENTS
         # ------------------------
-        elif [[ "$CURRENT_REF" =~ "$DEFAULT_BRANCH" ]]; then
+        elif [[ "$CURRENT_REF" == "$DEFAULT_BRANCH" ]]; then
           set_env "ENVIRONMENT=stage"
           set_output "environment=stage"
           echo "Matched default branch: stage"

--- a/action.yml
+++ b/action.yml
@@ -39,20 +39,20 @@ runs:
         echo "Current ref    : ${CURRENT_REF}"
         echo
 
+        re_pkg_prod='^.+@[0-9]+\.[0-9]+\.[0-9]+$'
+        re_pkg_uat='^.+@[0-9]+\.[0-9]+\.[0-9]+-uat\.[0-9]+$'
+
         # ------------------------
         # STANDARD CONVENTION
         # ------------------------
-        re_standard_prod='^v[0-9]+\.[0-9]+\.[0-9]+$'
-        re_standard_uat='^v[0-9]+\.[0-9]+\.[0-9]+-uat\.[0-9]+$'
-
         # vX.Y.Z -> production
-        if [[ "$CURRENT_REF" =~ $re_standard_prod ]]; then
+        if [[ "$CURRENT_REF" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
           set_env "ENVIRONMENT=production"
           set_output "environment=production"
           echo "Matched standard convention: production"
 
         # vX.Y.Z-uat.N -> uat
-        elif [[ "$CURRENT_REF" =~ $re_standard_uat ]]; then
+        elif [[ "$CURRENT_REF" =~ ^v[0-9]+\.[0-9]+\.[0-9]+-uat\.[0-9]+$ ]]; then
           set_env "ENVIRONMENT=uat"
           set_output "environment=uat"
           echo "Matched standard convention: uat"
@@ -60,8 +60,6 @@ runs:
         # ------------------------
         # PACKAGE CONVENTION
         # ------------------------
-        re_pkg_prod='^.+@[0-9]+\.[0-9]+\.[0-9]+$'
-        re_pkg_uat='^.+@[0-9]+\.[0-9]+\.[0-9]+-uat\.[0-9]+$'
 
         # pkg@X.Y.Z or @scope/pkg@X.Y.Z -> production
         elif [[ "$CURRENT_REF" =~ $re_pkg_prod ]]; then
@@ -95,5 +93,3 @@ runs:
           echo "  - Package: <pkg>@X.Y.Z | <pkg>@X.Y.Z-uat.N | @scope/<pkg>@X.Y.Z"
           exit 1
         fi
-
-        echo "Final ENVIRONMENT: $(grep '^ENVIRONMENT=' \"$GITHUB_ENV\" | tail -1 | cut -d= -f2)"

--- a/action.yml
+++ b/action.yml
@@ -76,7 +76,7 @@ runs:
         # ------------------------
         # BRANCH / EVENTS
         # ------------------------
-        elif [[ "$CURRENT_REF" =~ "$DEFAULT_BRANCH" ]];; then
+        elif [[ "$CURRENT_REF" =~ "$DEFAULT_BRANCH" ]]; then
           set_env "ENVIRONMENT=stage"
           set_output "environment=stage"
           echo "Matched default branch: stage"

--- a/action.yml
+++ b/action.yml
@@ -10,134 +10,77 @@ outputs:
     description: 'Target environment to use'
     value: ${{ steps.set-environment.outputs.environment }}
 
-
-    
 runs:
   using: "composite"
   steps:
-  - name: Determine current environment using the current git ref
-    shell: bash -leo pipefail {0}
-    id: set-environment
-    run: |
-      set_env()   { echo "$1" >> "$GITHUB_ENV"; }
-      set_output() { echo "$1" >> "$GITHUB_OUTPUT"; }
+    - name: Determine current environment using the current git ref
+      shell: bash -leo pipefail {0}
+      id: set-environment
+      run: |
+        set_env()    { echo "$1" >> "$GITHUB_ENV"; }
+        set_output() { echo "$1" >> "$GITHUB_OUTPUT"; }
 
-      echo "== Debug env (trimmed to GITHUB_*) =="
-      env | grep ^GITHUB_ || true
-      echo
+        echo "== Debug: GITHUB env =="
+        env | grep ^GITHUB_ || true
 
-      DEV_EVENTS=(push pull_request workflow_dispatch)
-      DEFAULT_BRANCH=$(git remote show origin 2>/dev/null | sed -n '/HEAD branch/s/.*: //p')
-      CURRENT_REF=${GITHUB_REF##*/}
+        DEV_EVENTS=(push pull_request workflow_dispatch)
+        DEFAULT_BRANCH=$(git remote show origin 2>/dev/null | sed -n '/HEAD branch/s/.*: //p')
+        CURRENT_REF=${GITHUB_REF##*/}
 
-      echo "Default branch : ${DEFAULT_BRANCH:-<unknown>}"
-      echo "GITHUB_REF     : ${GITHUB_REF}"
-      echo "Current ref    : ${CURRENT_REF}"
-      echo
+        echo "Default branch : ${DEFAULT_BRANCH:-<unknown>}"
+        echo "GITHUB_REF     : ${GITHUB_REF}"
+        echo "Current ref    : ${CURRENT_REF}"
+        echo
 
-      # -------------------------
-      # Regex helpers (unquoted!)
-      # -------------------------
-      # Old tags
-      re_old_prod='^v[0-9]+\.[0-9]+\.[0-9]+$'
-      re_old_uat='^v[0-9]+\.[0-9]+\.[0-9]+-uat\.[0-9]+$'
+        # ------------------------
+        # STANDARD CONVENTION
+        # ------------------------
+        # vX.Y.Z -> production
+        if [[ "$CURRENT_REF" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+          set_env "ENVIRONMENT=production"
+          set_output "environment=production"
+          echo "Matched standard convention: production"
 
-      # New tags (be liberal): anything ending with @<semver> or @<semver>-uat.N
-      # Accept multiple path segments and extra '@' in path.
-      re_new_uat='^.+@[0-9]+\.[0-9]+\.[0-9]+-uat\.[0-9]+$'
-      re_new_prod='^.+@[0-9]+\.[0-9]+\.[0-9]+$'
+        # vX.Y.Z-uat.N -> uat
+        elif [[ "$CURRENT_REF" =~ ^v[0-9]+\.[0-9]+\.[0-9]+-uat\.[0-9]+$ ]]; then
+          set_env "ENVIRONMENT=uat"
+          set_output "environment=uat"
+          echo "Matched standard convention: uat"
 
-      # -------------- MATCHES --------------
-      if [[ "$CURRENT_REF" =~ $re_old_prod ]]; then
-        echo "Matched: old production ($re_old_prod)"
-        set_env "ENVIRONMENT=production"; set_output "environment=production"
+        # ------------------------
+        # PACKAGE CONVENTION
+        # ------------------------
+        # pkg@X.Y.Z or @scope/pkg@X.Y.Z -> production
+        elif [[ "$CURRENT_REF" =~ ^.+@[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+          set_env "ENVIRONMENT=production"
+          set_output "environment=production"
+          echo "Matched package convention: production"
 
-      elif [[ "$CURRENT_REF" =~ $re_old_uat ]]; then
-        echo "Matched: old uat ($re_old_uat)"
-        set_env "ENVIRONMENT=uat"; set_output "environment=uat"
+        # pkg@X.Y.Z-uat.N or @scope/pkg@X.Y.Z-uat.N -> uat
+        elif [[ "$CURRENT_REF" =~ ^.+@[0-9]+\.[0-9]+\.[0-9]+-uat\.[0-9]+$ ]]; then
+          set_env "ENVIRONMENT=uat"
+          set_output "environment=uat"
+          echo "Matched package convention: uat"
 
-      # Check UAT before prod so -uat.N doesn't fall through to prod
-      elif [[ "$CURRENT_REF" =~ $re_new_uat ]]; then
-        echo "Matched: new uat ($re_new_uat)"
-        set_env "ENVIRONMENT=uat"; set_output "environment=uat"
+        # ------------------------
+        # BRANCH / EVENTS
+        # ------------------------
+        elif [[ -n "$DEFAULT_BRANCH" && "$CURRENT_REF" == "$DEFAULT_BRANCH" ]]; then
+          set_env "ENVIRONMENT=stage"
+          set_output "environment=stage"
+          echo "Matched default branch: stage"
 
-      elif [[ "$CURRENT_REF" =~ $re_new_prod ]]; then
-        echo "Matched: new production ($re_new_prod)"
-        set_env "ENVIRONMENT=production"; set_output "environment=production"
+        elif [[ " ${DEV_EVENTS[*]} " == *" $GITHUB_EVENT_NAME "* ]]; then
+          set_env "ENVIRONMENT=stage"
+          set_output "environment=stage"
+          echo "Matched dev event: stage"
 
-      elif [[ -n "$DEFAULT_BRANCH" && "$CURRENT_REF" == "$DEFAULT_BRANCH" ]]; then
-        echo "Matched: default branch"
-        set_env "ENVIRONMENT=stage"; set_output "environment=stage"
+        else
+          echo "Error: ref '$CURRENT_REF' does not match any supported convention."
+          echo "Supported conventions:"
+          echo "  - Standard: vX.Y.Z | vX.Y.Z-uat.N"
+          echo "  - Package: <pkg>@X.Y.Z | <pkg>@X.Y.Z-uat.N | @scope/<pkg>@X.Y.Z"
+          exit 1
+        fi
 
-      elif [[ " ${DEV_EVENTS[*]} " == *" $GITHUB_EVENT_NAME "* ]]; then
-        echo "Matched: dev event ($GITHUB_EVENT_NAME)"
-        set_env "ENVIRONMENT=stage"; set_output "environment=stage"
-
-      else
-        echo "Error: ref '$CURRENT_REF' does not match any supported convention."
-        echo " Hint: expected one of:"
-        echo "   - vX.Y.Z"
-        echo "   - vX.Y.Z-uat.N"
-        echo "   - <anything>@X.Y.Z"
-        echo "   - <anything>@X.Y.Z-uat.N"
-        exit 1
-      fi
-
-      echo "ENVIRONMENT => $(grep '^ENVIRONMENT=' "$GITHUB_ENV" | tail -1 | cut -d= -f2)"
-
-
-  # - name: Determine current environment using the current git ref
-  #   shell: bash -leo pipefail {0}
-  #   id: set-environment
-  #   run: |
-  #     set_env() { echo "$1" >> "$GITHUB_ENV"; }
-  #     set_output() { echo "$1" >> "$GITHUB_OUTPUT"; }
-
-  #     echo "Printing current environment variables for debugging purposes..."
-  #     env | grep GITHUB_
-
-  #     DEV_EVENTS=(push pull_request workflow_dispatch)
-  #     DEFAULT_BRANCH=$(git remote show origin | sed -n '/HEAD branch/s/.*: //p')
-  #     CURRENT_REF=${GITHUB_REF##*/}
-
-  #     echo "Identified default branch : ${DEFAULT_BRANCH}"
-  #     echo "Current git reference     : ${CURRENT_REF}"
-
-  #     # Convetional release: vX.Y.Z
-  #     if [[ "$CURRENT_REF" =~ ^v([0-9]+\.[0-9]+\.[0-9]+)$ ]]; then
-  #       set_env "ENVIRONMENT=production"
-  #       set_output "environment=production"
-  #       echo "ENVIRONMENT set to 'production'."
-
-  #     elif [[ "$CURRENT_REF" =~ ^v([0-9]+\.[0-9]+\.[0-9]+)-uat\.([0-9]+)$ ]]; then
-  #       set_env "ENVIRONMENT=uat"
-  #       set_output "environment=uat"
-  #       echo "ENVIRONMENT set to 'uat'."
-
-  #     # Convetional release: @scope/pkg@X.Y.Z  OR  pkg@X.Y.Z
-  #     elif [[ "$CURRENT_REF" =~ ^(@[^@/]+/)?[^@]+@[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-  #       set_env "ENVIRONMENT=production"
-  #       set_output "environment=production"
-  #       echo "ENVIRONMENT set to 'production'."
-
-  #     elif [[ "$CURRENT_REF" =~ ^(@[^@/]+/)?[^@]+@[0-9]+\.[0-9]+\.[0-9]+-uat\.[0-9]+$ ]]; then
-  #       set_env "ENVIRONMENT=uat"
-  #       set_output "environment=uat"
-  #       echo "ENVIRONMENT set to 'uat'."
-
-  #     elif [[ "$CURRENT_REF" =~ "$DEFAULT_BRANCH" ]]; then
-  #       set_env "ENVIRONMENT=stage"
-  #       set_output "environment=stage"
-  #       echo "ENVIRONMENT set to 'stage' (default branch)."
-
-  #     elif [[ "${DEV_EVENTS[*]}" =~ "$GITHUB_EVENT_NAME" ]]; then
-  #       set_env "ENVIRONMENT=stage"
-  #       set_output "environment=stage"
-  #       echo "ENVIRONMENT set to 'stage'."
-
-  #     else
-  #       echo "Error:"
-  #       echo "The ref '$CURRENT_REF' does not match any supported conventions."
-  #       echo "Check the README's 'Releases and deployments' section for details."
-  #       exit 1
-  #     fi
+        echo "Final ENVIRONMENT: $(grep '^ENVIRONMENT=' \"$GITHUB_ENV\" | tail -1 | cut -d= -f2)"

--- a/action.yml
+++ b/action.yml
@@ -26,18 +26,21 @@ runs:
         DEV_EVENTS=(push pull_request workflow_dispatch)
         DEFAULT_BRANCH=$(git remote show origin 2>/dev/null | sed -n '/HEAD branch/s/.*: //p')
 
+        CURRENT_REF=${GITHUB_REF##*/}
         # Input ref handling
         if [[ -n "${FORCE_REF:-}" ]]; then
           echo "⚡ Overriding GITHUB_REF with FORCE_REF=$FORCE_REF"
           GITHUB_REF="$FORCE_REF"
         fi
 
-        CURRENT_REF=${GITHUB_REF##*/}
 
         echo "Default branch : ${DEFAULT_BRANCH:-<unknown>}"
         echo "GITHUB_REF     : ${GITHUB_REF}"
         echo "Current ref    : ${CURRENT_REF}"
         echo
+
+        re_pkg_prod='^.+@[0-9]+\.[0-9]+\.[0-9]+$'
+        re_pkg_uat='^.+@[0-9]+\.[0-9]+\.[0-9]+-uat\.[0-9]+$'
 
         # ------------------------
         # STANDARD CONVENTION
@@ -58,13 +61,13 @@ runs:
         # PACKAGE CONVENTION
         # ------------------------
         # pkg@X.Y.Z or @scope/pkg@X.Y.Z -> production
-        elif [[ "$CURRENT_REF" =~ ^.+@[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+        elif [[ "$CURRENT_REF" =~ $re_pkg_prod ]]; then
           set_env "ENVIRONMENT=production"
           set_output "environment=production"
           echo "Matched package convention: production"
 
         # pkg@X.Y.Z-uat.N or @scope/pkg@X.Y.Z-uat.N -> uat
-        elif [[ "$CURRENT_REF" =~ ^.+@[0-9]+\.[0-9]+\.[0-9]+-uat\.[0-9]+$ ]]; then
+        elif [[ "$CURRENT_REF" =~ $re_pkg_uat ]]; then
           set_env "ENVIRONMENT=uat"
           set_output "environment=uat"
           echo "Matched package convention: uat"

--- a/action.yml
+++ b/action.yml
@@ -30,12 +30,12 @@ runs:
         echo "Current git reference     : ${CURRENT_REF}"
 
         # Convetional release: vX.Y.Z
-        if [[ "$CURRENT_REF" =~ ^v([0-9]{1,2}.[0-9]{1,2}.[0-9]{1,2})$ ]]; then
+        if [[ "$CURRENT_REF" =~ ^v([0-9]+\.[0-9]+\.[0-9]+)$ ]]; then
           set_env "ENVIRONMENT=production"
           set_output "environment=production"
           echo "ENVIRONMENT set to 'production'."
 
-        elif [[ "$CURRENT_REF" =~ ^v([0-9]{1,2}.[0-9]{1,2}.[0-9]{1,2})(-uat.[0-9]{1,2})$ ]]; then
+        elif [[ "$CURRENT_REF" =~ ^v([0-9]+\.[0-9]+\.[0-9]+)-uat\.([0-9]+)$ ]]; then
           set_env "ENVIRONMENT=uat"
           set_output "environment=uat"
           echo "ENVIRONMENT set to 'uat'."

--- a/action.yml
+++ b/action.yml
@@ -73,15 +73,20 @@ runs:
         # ------------------------
         # BRANCH / EVENTS
         # ------------------------
-        elif [[ "$CURRENT_REF" =~ "$DEFAULT_BRANCH" ]]; then
+        # stage if we're on the default branch (only when DEFAULT_BRANCH is known)
+        elif [[ -n "$DEFAULT_BRANCH" && "$CURRENT_REF" == "$DEFAULT_BRANCH" ]]; then
           set_env "ENVIRONMENT=stage"
           set_output "environment=stage"
           echo "Matched default branch: stage"
 
-        elif [[ "${DEV_EVENTS[*]}" =~ "$GITHUB_EVENT_NAME" ]]; then
+        # stage for PR/push/workflow_dispatch events
+        elif [[ " ${DEV_EVENTS[*]} " == *" ${GITHUB_EVENT_NAME} "* ]]; then
+          # DEV_EVENTS=(push pull_request workflow_dispatch)
+          # Works for: pull_request (refs/pull/.../merge), push, workflow_dispatch
           set_env "ENVIRONMENT=stage"
           set_output "environment=stage"
           echo "Matched dev event: stage"
+
 
         else
           echo "Error: ref '$CURRENT_REF' does not match any supported convention."


### PR DESCRIPTION
## Summary

Update action to support new convention

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add package tag and FORCE_REF support to environment-detection action and introduce comprehensive CI tests covering tags, branches, invalid refs, and PR context.
> 
> - **Action (`action.yml`)**:
>   - Add `FORCE_REF` override to simulate refs; enhance debug output and safe file writes.
>   - Broaden version matching with robust regex; support standard `vX.Y.Z`/`vX.Y.Z-uat.N` and package refs `<pkg>@X.Y.Z`/`<pkg>@X.Y.Z-uat.N` (including scoped).
>   - Refine branch/event handling (exact default-branch match); clearer errors and final ENV echo.
> - **CI (`.github/workflows/tests.yml`)**:
>   - Rename workflow/job and extend PR branches; fix `CODE_OF_CONDUCT` path.
>   - Replace simple check with comprehensive tests:
>     - Conventional prod/uat tags (`v1.0.0`, `v1.0.0-uat.1`).
>     - Package prod/uat refs (`@gbh-tech/internal-jobs@1.0.0`, `...@1.0.0-uat.1`).
>     - Invalid tag expected failure.
>     - Branch `main` and current PR context resolve to `stage`.
>     - Verify `ENVIRONMENT` variable is set.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1768e2146aef0050f69994bbfb8df7cb93081b18. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->